### PR TITLE
Allow more non-standard computation mnemonics

### DIFF
--- a/assembler/src/code.rs
+++ b/assembler/src/code.rs
@@ -12,6 +12,9 @@ impl Code {
     pub fn comp(mnemonic: &str) -> Result<&'static str, String> {
         // Non-standard but convenient remappings
         let canonical = match mnemonic {
+            "A+D" => "D+A",
+            "A&D" => "D&A",
+            "A|D" => "D|A",
             "M+D" => "D+M",
             "M&D" => "D&M",
             "M|D" => "D|M",


### PR DESCRIPTION
Our VM translator [tries to use `A+D`](https://github.com/computationclub/vm-translator/blob/44d37b22393d42773402d4419694d039d528fad6/lib/code_writer.rb#L166). The emulator might as well support it.
